### PR TITLE
Added support to list files in the Storage bucket

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Current
 - Improved backend documentation
 - Use setuptools entry points to register backends.
 - Added `NONE` extensions specification
+- Added `list_files` to `Storage` to list the current bucket files
 
 0.3.0 (2017-03-05)
 ------------------

--- a/flask_fs/backends/gridfs.py
+++ b/flask_fs/backends/gridfs.py
@@ -60,6 +60,10 @@ class GridFsBackend(BaseBackend):
         for version in self.fs.find({'filename': filename}):
             self.fs.delete(version._id)
 
+    def list_files(self):
+        for f in self.fs.list():
+            yield f
+
     def serve(self, filename):
         file = self.fs.get_last_version(filename)
         return send_file(file, mimetype=file.content_type)

--- a/flask_fs/backends/local.py
+++ b/flask_fs/backends/local.py
@@ -75,6 +75,11 @@ class LocalBackend(BaseBackend):
                 copyfileobj(file_or_wfs, out)
         return filename
 
+    def list_files(self):
+        for dirpath, dirnames, filenames in os.walk(self.root):
+            for f in filenames:
+                yield f
+
     def path(self, filename):
         '''Return the full path for a given filename in the storage'''
         return os.path.join(self.root, filename)

--- a/flask_fs/backends/s3.py
+++ b/flask_fs/backends/s3.py
@@ -74,6 +74,10 @@ class S3Backend(BaseBackend):
     def delete(self, filename):
         self.bucket.Object(filename).delete()
 
+    def list_files(self):
+        for f in self.bucket.objects.all():
+            yield f.key
+
     # def serve(self, filename):
     #     file = self.fs.get_last_version(filename)
     #     return send_file(file, mimetype=file.content_type)

--- a/flask_fs/backends/swift.py
+++ b/flask_fs/backends/swift.py
@@ -59,3 +59,8 @@ class SwiftBackend(BaseBackend):
 
     def delete(self, filename):
         self.conn.delete_object(self.name, filename)
+
+    def list_files(self):
+        headers, items = self.conn.get_container(self.name)
+        for i in items:
+            yield i['name']

--- a/flask_fs/storage.py
+++ b/flask_fs/storage.py
@@ -301,6 +301,12 @@ class Storage(object):
 
         return filename
 
+    def list_files(self):
+        '''
+        Returns a filename generator to iterate through all the file in the storage bucket
+        '''
+        return self.backend.list_files()
+
     def __contains__(self, value):
         return self.exists(value)
 

--- a/tests/test_backend_mixin.py
+++ b/tests/test_backend_mixin.py
@@ -134,3 +134,10 @@ class BackendTestCase(object):
         self.backend.save(storage, filename)
 
         self.assert_text_equal(filename, content)
+
+    def test_list_files(self, faker, utils):
+        for f in ['first.test', 'second.test']:
+            content = six.text_type(faker.sentence())
+            self.put_file(f, content)
+
+        assert sorted(list(self.backend.list_files())) == ['first.test', 'second.test']

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -409,3 +409,13 @@ def test_path_not_supported(app, mock_backend):
 
     with pytest.raises(fs.OperationNotSupported):
         storage.path('file.test')
+
+
+def test_list_files(app, mock_backend):
+    storage = fs.Storage('test')
+    backend = mock_backend.return_value
+    backend.list_files.return_value = ['one.txt']
+
+    app.configure(storage)
+
+    assert storage.list_files() == ['one.txt']

--- a/tests/test_swift_backend.py
+++ b/tests/test_swift_backend.py
@@ -35,9 +35,13 @@ class SwiftBackendTest(BackendTestCase):
         yield
 
         try:
+            headers, items = self.conn.get_container(self.backend.name)
+            for i in items:
+                self.conn.delete_object(self.backend.name, i['name'])
+
             self.conn.delete_container(self.backend.name)
         except swiftclient.ClientException as e:
-            print(e)
+            assert False, "Failed to delete container ->" + str(e)
 
     def put_file(self, filename, content):
         self.conn.put_object(self.container, filename, contents=content)


### PR DESCRIPTION
This PR intends to add a method on the Storage class to list files in the bucket.
It also fixes the Swift tests that were not properly deleting the bucket on each run.

Tested successfully, using tox on python 2.7, 3.5
