### PR TITLE
Allow passing kwargs to backends for advanced initialization needs

### DIFF
--- a/flask_fs/backends/__init__.py
+++ b/flask_fs/backends/__init__.py
@@ -15,7 +15,7 @@ class BaseBackend(object):
     '''
     root = None
 
-    def __init__(self, name, config):
+    def __init__(self, name, config, **kwargs):
         self.name = name
         self.config = config
 

--- a/flask_fs/backends/__init__.py
+++ b/flask_fs/backends/__init__.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from ..storage import Config, KWARGS_CONFIG_ATTR_SUFFIX
+
 import six
 
 __all__ = [i.encode('ascii') for i in ('BaseBackend', 'DEFAULT_BACKEND')]
@@ -15,9 +17,15 @@ class BaseBackend(object):
     '''
     root = None
 
-    def __init__(self, name, config, **kwargs):
+    def __init__(self, name, config):
         self.name = name
         self.config = config
+        # ensure new connection config is in place
+        self.kwargs_config = self.config.setdefault(self.backend_name + KWARGS_CONFIG_ATTR_SUFFIX,
+                                                    Config())
+        # user may have an existing config, honour that, translating to new dict entry
+        if hasattr(self, '_convert_legacy_config'):
+            self._convert_legacy_config()
 
     def exists(self, filename):
         '''Test wether a file exists or not given its filename in the storage'''

--- a/flask_fs/backends/gridfs.py
+++ b/flask_fs/backends/gridfs.py
@@ -26,10 +26,10 @@ class GridFsBackend(BaseBackend):
     - `mongo_url`: The Mongo access URL
     - `mongo_db`: The database to store the file in.
     '''
-    def __init__(self, name, config):
+    def __init__(self, name, config, **kwargs):
         super(GridFsBackend, self).__init__(name, config)
 
-        self.client = MongoClient(config.mongo_url)
+        self.client = MongoClient(config.mongo_url, **kwargs)
         self.db = self.client[config.mongo_db]
         self.fs = GridFS(self.db, self.name)
 

--- a/flask_fs/backends/gridfs.py
+++ b/flask_fs/backends/gridfs.py
@@ -26,12 +26,16 @@ class GridFsBackend(BaseBackend):
     - `mongo_url`: The Mongo access URL
     - `mongo_db`: The database to store the file in.
     '''
-    def __init__(self, name, config, **kwargs):
+    def __init__(self, name, config):
         super(GridFsBackend, self).__init__(name, config)
 
-        self.client = MongoClient(config.mongo_url, **kwargs)
+        self.client = MongoClient(**config.gridfs_kwargs)
         self.db = self.client[config.mongo_db]
         self.fs = GridFS(self.db, self.name)
+
+    def _convert_legacy_config(self):
+        if 'mongo_url' in self.config:
+            self.kwargs_config.setdefault('host', self.config.mongo_url)
 
     def exists(self, filename):
         return self.fs.exists(filename=filename)

--- a/flask_fs/backends/s3.py
+++ b/flask_fs/backends/s3.py
@@ -27,7 +27,7 @@ class S3Backend(BaseBackend):
     - `access_key`: The AWS credential access key
     - `secret_key`: The AWS credential secret key
     '''
-    def __init__(self, name, config):
+    def __init__(self, name, config, **kwargs):
         super(S3Backend, self).__init__(name, config)
 
         self.session = boto3.session.Session()
@@ -38,7 +38,7 @@ class S3Backend(BaseBackend):
                                         endpoint_url=config.endpoint,
                                         region_name=config.region,
                                         aws_access_key_id=config.access_key,
-                                        aws_secret_access_key=config.secret_key)
+                                        aws_secret_access_key=config.secret_key, **kwargs)
         self.bucket = self.s3.Bucket(name)
 
         try:

--- a/flask_fs/backends/swift.py
+++ b/flask_fs/backends/swift.py
@@ -23,13 +23,14 @@ class SwiftBackend(BaseBackend):
     - `user`: The Swift user in
     - `key`: The user API Key
     '''
-    def __init__(self, name, config):
+    def __init__(self, name, config, **kwargs):
         super(SwiftBackend, self).__init__(name, config)
 
         self.conn = swiftclient.Connection(
             user=config.user,
             key=config.key,
-            authurl=config.authurl
+            authurl=config.authurl,
+            **kwargs
         )
         self.conn.put_container(self.name)
 

--- a/flask_fs/backends/swift.py
+++ b/flask_fs/backends/swift.py
@@ -10,6 +10,7 @@ import swiftclient
 
 from . import BaseBackend
 
+
 log = logging.getLogger(__name__)
 
 
@@ -23,16 +24,21 @@ class SwiftBackend(BaseBackend):
     - `user`: The Swift user in
     - `key`: The user API Key
     '''
-    def __init__(self, name, config, **kwargs):
+    def __init__(self, name, config):
         super(SwiftBackend, self).__init__(name, config)
 
         self.conn = swiftclient.Connection(
-            user=config.user,
-            key=config.key,
-            authurl=config.authurl,
-            **kwargs
+            **config.swift_kwargs
         )
         self.conn.put_container(self.name)
+
+    def _convert_legacy_config(self):
+        if 'authurl' in self.config:
+            self.kwargs_config.setdefault('authurl', self.config.authurl)
+        if 'user' in self.config:
+            self.kwargs_config.setdefault('user', self.config.user)
+        if 'key' in self.config:
+            self.kwargs_config.setdefault('key', self.config.key)
 
     def exists(self, filename):
         try:

--- a/flask_fs/storage.py
+++ b/flask_fs/storage.py
@@ -74,15 +74,22 @@ class Storage(object):
         it should return the default upload destination path for that app.
     :param bool overwrite:
         Whether or not to allow overwriting
+    :param kwargs:
+        backend specific additonal parameters
     '''
 
-    def __init__(self, name='files', extensions=DEFAULTS, upload_to=None, overwrite=False):
+    def __init__(self, name='files',
+                 extensions=DEFAULTS,
+                 upload_to=None,
+                 overwrite=False,
+                 **kwargs):
         self.name = name
         self.extensions = extensions
         self.config = Config()
         self.upload_to = upload_to
         self.backend = None
         self.overwrite = overwrite
+        self.kwargs = kwargs
 
     def configure(self, app):
         '''
@@ -121,7 +128,7 @@ class Storage(object):
             raise ValueError('Unknown backend "{0}"'.format(self.backend_name))
         backend_class = BACKENDS[self.backend_name].load()
         backend_class.backend_name = self.backend_name
-        self.backend = backend_class(self.name, config)
+        self.backend = backend_class(self.name, config, **self.kwargs)
         self.config = config
 
     @cached_property

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ from werkzeug.datastructures import FileStorage
 
 import pytest
 
+
 BIN_FILE = os.path.join(os.path.dirname(__file__), 'flask.png')
 
 

--- a/tests/test_gridfs_backend.py
+++ b/tests/test_gridfs_backend.py
@@ -25,6 +25,7 @@ class GridFsBackendTest(BackendTestCase):
             'mongo_url': 'mongodb://localhost:27017',
             'mongo_db': TEST_DB,
         })
+        GridFsBackend.backend_name = 'gridfs'
         self.backend = GridFsBackend('test', self.config)
         yield
         self.client.drop_database(TEST_DB)
@@ -47,6 +48,10 @@ class GridFsBackendTest(BackendTestCase):
     def test_config(self):
         assert self.backend.client.address == ('localhost', 27017)
         assert self.backend.db.name == TEST_DB
+
+    def test_config_legacy_to_new(self):
+        assert 'gridfs_kwargs' in self.config
+        assert 'host' in self.config.gridfs_kwargs
 
     def test_delete_with_versions(self, faker):
         filename = 'test.txt'

--- a/tests/test_local_backend.py
+++ b/tests/test_local_backend.py
@@ -16,6 +16,7 @@ class LocalBackendTest(BackendTestCase):
         self.config = Config({
             'root': str(tmpdir),
         })
+        LocalBackend.backend_name = 'local'
         self.backend = LocalBackend('test', self.config)
 
     def filename(self, filename):

--- a/tests/test_s3_backend.py
+++ b/tests/test_s3_backend.py
@@ -46,6 +46,7 @@ class S3BackendTest(BackendTestCase):
             access_key=S3_ACCESS_KEY,
             secret_key=S3_SECRET_KEY
         )
+        S3Backend.backend_name = 's3'
         self.backend = S3Backend('test', self.config)
         yield
         for obj in self.bucket.objects.all():

--- a/tests/test_swift_backend.py
+++ b/tests/test_swift_backend.py
@@ -30,6 +30,7 @@ class SwiftBackendTest(BackendTestCase):
             'key': KEY,
             'authurl': AUTHURL,
         })
+        SwiftBackend.backend_name = 'swift'
         self.backend = SwiftBackend(self.container, self.config)
 
         yield


### PR DESCRIPTION
This PR allows more advanced backend configuration. In my use case, I needed to use swift authentication version 2, which needs additionnal parameters at backend initialization time:

i.e. 

```
storage = fs.Storage('myfs',
                    fs.ARCHIVES + fs.DATA,
                    auth_version='2',
                    tenant_name='my_tenant')

fs.init_app(app, storage)
```

