### PR TITLE
Add explicit file MIME-type when writing with GridFS backend

### DIFF
--- a/flask_fs/backends/gridfs.py
+++ b/flask_fs/backends/gridfs.py
@@ -54,10 +54,16 @@ class GridFsBackend(BaseBackend):
         return f.read()
 
     def write(self, filename, content):
+        kwargs = {
+            'filename': filename
+        }
+
+        if hasattr(content, 'content_type'):
+            kwargs['content_type'] = content.content_type
+
         return self.fs.put(
             self.as_binary(content),
-            filename=filename,
-            content_type=content.content_type
+            **kwargs
         )
 
     def delete(self, filename):

--- a/flask_fs/backends/gridfs.py
+++ b/flask_fs/backends/gridfs.py
@@ -58,7 +58,7 @@ class GridFsBackend(BaseBackend):
             'filename': filename
         }
 
-        if hasattr(content, 'content_type'):
+        if hasattr(content, 'content_type') and content.content_type is not None:
             kwargs['content_type'] = content.content_type
 
         return self.fs.put(self.as_binary(content), **kwargs)

--- a/flask_fs/backends/gridfs.py
+++ b/flask_fs/backends/gridfs.py
@@ -54,7 +54,11 @@ class GridFsBackend(BaseBackend):
         return f.read()
 
     def write(self, filename, content):
-        return self.fs.put(self.as_binary(content), filename=filename)
+        return self.fs.put(
+            self.as_binary(content),
+            filename=filename,
+            content_type=content.content_type
+        )
 
     def delete(self, filename):
         regex = '^{0}'.format(re.escape(filename))

--- a/flask_fs/backends/gridfs.py
+++ b/flask_fs/backends/gridfs.py
@@ -61,10 +61,7 @@ class GridFsBackend(BaseBackend):
         if hasattr(content, 'content_type'):
             kwargs['content_type'] = content.content_type
 
-        return self.fs.put(
-            self.as_binary(content),
-            **kwargs
-        )
+        return self.fs.put(self.as_binary(content), **kwargs)
 
     def delete(self, filename):
         regex = '^{0}'.format(re.escape(filename))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,8 +52,12 @@ def jpgfile():
 
 
 class Utils(object):
-    def filestorage(self, filename, content):
-        return FileStorage(self.file(content), filename)
+    def filestorage(self, filename, content, content_type=None):
+        return FileStorage(
+            self.file(content),
+            filename,
+            content_type=content_type
+        )
 
     def file(self, content):
         if isinstance(content, six.binary_type):


### PR DESCRIPTION
When using the GridFS backend and trying to serve files with it, the MIME-type cannot be found by Flask on the returned file. When writing a file to GridFS, the MIME-type should be included allowing to retrieve it when serving the file.

Run the following sample app to reproduce the issue:

```python
from flask import Flask, jsonify, request
import flask_fs as fs
import os
from uuid import uuid4

app = Flask(__name__)
app.config.update(
    FS_BACKEND=os.environ.get('STORAGE_BACKEND'),
    FS_GRIDFS_MONGO_URL=os.environ.get('MONGO_URL'),
    FS_GRIDFS_MONGO_DB=os.environ.get('MONGO_DB')
)

uploads = fs.Storage('uploads')
fs.init_app(app, uploads)

@app.route('/upload', methods=['POST'])
def upload():
    content = request.files.get('content')
    if not content or content.filename == '':
        abort(HTTPStatus.BAD_REQUEST)

    filename = str(uuid4())
    uploads.write(filename, content)
    upload_url = uploads.url(filename)
    return jsonify({
        'upload_url': upload_url
    })

if __name__ == '__main__':
    app.run(debug=True)
```

```shell
$ export STORAGE_BACKEND="gridfs"
$ export MONGO_URL="mongodb://localhost:27017"
$ export MONGO_DB="uploads"
$ python app.py
```

Perform the following requests to observe the issue:

```shell
$ http -f POST localhost:5000/upload content@<path/to/file.{png,jpg}>
HTTP/1.0 200 OK
Access-Control-Allow-Origin: *
Content-Length: 68
Content-Type: application/json
Date: Wed, 11 Apr 2018 13:14:41 GMT
Server: Werkzeug/0.14.1 Python/3.6.5

{
    "upload_url": "/uploads/c5c195f1-41a9-41ad-a923-0111e51d4127"
}
```
```shell
$ http GET localhost:5000/uploads/c5c195f1-41a9-41ad-a923-0111e51d4127
HTTP/1.0 500 INTERNAL SERVER ERROR
Connection: close
Content-Type: text/html; charset=utf-8
Date: Wed, 11 Apr 2018 13:15:03 GMT
Server: Werkzeug/0.14.1 Python/3.6.5
X-XSS-Protection: 0

127.0.0.1 - - [11/Apr/2018 15:28:59] "GET /uploads/c5c195f1-41a9-41ad-a923-0111e51d4127 HTTP/1.1" 500 -
Traceback (most recent call last):
  File "/lib/python3.6/site-packages/flask/app.py", line 1997, in __call__
    return self.wsgi_app(environ, start_response)
  File "/lib/python3.6/site-packages/flask/app.py", line 1985, in wsgi_app
    response = self.handle_exception(e)
  File "/lib/python3.6/site-packages/flask/app.py", line 1540, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/lib/python3.6/site-packages/flask/_compat.py", line 33, in reraise
    raise value
  File "/lib/python3.6/site-packages/flask/app.py", line 1982, in wsgi_app
    response = self.full_dispatch_request()
  File "/lib/python3.6/site-packages/flask/app.py", line 1614, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/lib/python3.6/site-packages/flask/app.py", line 1517, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/lib/python3.6/site-packages/flask/_compat.py", line 33, in reraise
    raise value
  File "/lib/python3.6/site-packages/flask/app.py", line 1612, in full_dispatch_request
    rv = self.dispatch_request()
  File "/lib/python3.6/site-packages/flask/app.py", line 1598, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/lib/python3.6/site-packages/flask_fs/views.py", line 17, in get_file
    return storage.serve(filename)
  File "/lib/python3.6/site-packages/flask_fs/storage.py", line 354, in serve
    return self.backend.serve(filename)
  File "/lib/python3.6/site-packages/flask_fs/backends/gridfs.py", line 78, in serve
    return send_file(file, mimetype=file.content_type)
  File "/lib/python3.6/site-packages/flask/helpers.py", line 527, in send_file
    'Unable to infer MIME-type because no filename is available. '
ValueError: Unable to infer MIME-type because no filename is available. Please set either `attachment_filename`, pass a filepath to `filename_or_fp` or set your own MIME-type via `mimetype`.
```

**Packages versions**
Flask (0.12.2)
flask-fs (0.6.0)
