### PR TITLE
Add AUTH_VERSION and OS_OPTIONS to Swift backend

### DIFF
--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -44,7 +44,8 @@ Expect the following settings:
 - ``AUTHURL``: The Swift Auth URL
 - ``USER``: The Swift user in
 - ``KEY``: The user API Key
-
+- ``AUTH_VERSION``: The OpenStack auth version (optional, default: ``'1'``)
+- ``OS_OPTIONS``: The OpenStack options as a dictonnary with keys such as `region_name` (optional, default: ``None``)
 
 Custom backends
 ---------------

--- a/flask_fs/backends/swift.py
+++ b/flask_fs/backends/swift.py
@@ -27,10 +27,15 @@ class SwiftBackend(BaseBackend):
     def __init__(self, name, config):
         super(SwiftBackend, self).__init__(name, config)
 
+        auth_version = getattr(config, 'auth_version', '1')
+        os_options = getattr(config, 'os_options', None)
+
         self.conn = swiftclient.Connection(
             user=config.user,
             key=config.key,
-            authurl=config.authurl
+            authurl=config.authurl,
+            auth_version=auth_version,
+            os_options=os_options
         )
         self.conn.put_container(self.name)
 


### PR DESCRIPTION
When using the Swift backend with some provider, some more options might be required.
For instance, when using OVH Object Storage service, OpenStack Swift Authentication v2 is required along with specifying the region name.

This PR allows to further configure the `swiftclient` library using optional variables:
- `AUTH_VERSION`: The OpenStack auth version (optional, default: "1")
- `OS_OPTIONS`: The OpenStack options as a dictionary with keys such as `region_name` (optional, default: `None`)

When configuring `flask-fs`, the `flask` user config for the Swift backend can look like:

```python
    FS_SWIFT_AUTHURL = os.environ.get('SWIFT_AUTHURL')
    FS_SWIFT_AUTH_VERSION = os.environ.get('SWIFT_AUTH_VERSION')
    FS_SWIFT_OS_OPTIONS = {
        'region_name': os.environ.get('SWIFT_REGION_NAME')
    }
    FS_SWIFT_USER = os.environ.get('SWIFT_USER')
    FS_SWIFT_KEY = os.environ.get('SWIFT_KEY')
    FS_SWIFT_URL = os.environ.get('SWIFT_URL')
```

I did not add some more tests for the Swift backend as I currently do not know how to test these options with the used Docker image `morrisjobke/docker-swift-onlyone`.
However, I tested it successfully with a production-grade web-service.

Let me know if there is anything I can to make this better.