### PR TITLE
s3: Use connection region to create bucket

### DIFF
--- a/flask_fs/backends/s3.py
+++ b/flask_fs/backends/s3.py
@@ -41,10 +41,13 @@ class S3Backend(BaseBackend):
                                         aws_secret_access_key=config.secret_key)
         self.bucket = self.s3.Bucket(name)
 
-        try:
-            self.bucket.create()
-        except self.s3.meta.client.exceptions.BucketAlreadyOwnedByYou:
-            pass
+        if self.bucket.creation_date is None:
+            # Boto3 does not automatically get the region from the conneciton information
+            # They use the default US Standard region.
+            # Ref: https://github.com/boto/boto3/issues/781
+            self.bucket.create(CreateBucketConfiguration={
+                'LocationConstraint': self.s3.meta.client.meta.region_name
+            })
 
     def exists(self, filename):
         try:


### PR DESCRIPTION
Boto3 always tries to create the bucket in US Standard (N. Virginia)
region unless explicitly mentioned. So, give it the region of the
connection so that it does raise an error about IllegalLocation.

Fixes: https://github.com/noirbizarre/flask-fs/issues/31